### PR TITLE
[V2] Skillforge Widget: Fix broken theme mode

### DIFF
--- a/apps/skillforge-ui/src/web3/connectors/index.ts
+++ b/apps/skillforge-ui/src/web3/connectors/index.ts
@@ -15,7 +15,7 @@ function _getWhitelistTheme(): PstlWeb3AuthParameters['uiConfig'] {
     theme: {
       primary: skillforgeTheme.modes.DEFAULT.mainBgDarker
     },
-    mode: 'DARK',
+    mode: 'dark',
     logoDark: ASSETS_MAP.logos.forge[512],
     logoLight: ASSETS_MAP.logos.forge[512]
   }


### PR DESCRIPTION
Fixes broken "DARK" theme mode to 'dark' as type specifies