### PR TITLE
feat(web3-modal): default fallback transports + deprecate options

### DIFF
--- a/packages/web3-modal/src/fixtures/config.tsx
+++ b/packages/web3-modal/src/fixtures/config.tsx
@@ -1,5 +1,6 @@
 import { devDebug } from '@past3lle/utils'
 import { http } from 'viem'
+import { fallback } from 'wagmi'
 
 import { PstlWeb3ModalProps } from '../providers'
 import { createTheme } from '../theme'
@@ -211,29 +212,20 @@ const CHAIN_IMAGES: ChainImages = {
   137: 'https://icons.llamao.fi/icons/chains/rsz_polygon.jpg'
 }
 
-const DEFAULT_PROPS: PstlWeb3ModalProps = {
+const DEFAULT_PROPS = {
   appName: 'COSMOS APP',
   chains,
   connectors: {
     overrides: COMMON_CONNECTOR_OVERRIDES
   },
-  clients: {
-    wagmi: {
-      options: {
-        transports: {
-          1: http(`https://eth-mainnet.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_GOERLI_API_KEY as string}`),
-          5: http(`https://eth-goerli.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_GOERLI_API_KEY as string}`),
-          137: http(
-            `https://polygon-mainnet.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_MATIC_API_KEY as string}`
-          ),
-          80001: http(
-            `https://polygon-mumbai.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_MUMBAI_API_KEY as string}`
-          )
-        }
-      }
-    }
-  },
   options: {
+    transports: {
+      5: fallback([
+        http(`https://eth-goerli.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_GOERLI_API_KEY as string}`)
+      ]),
+      137: http(`https://polygon-mainnet.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_MATIC_API_KEY as string}`),
+      80001: http(`https://polygon-mumbai.g.alchemy.com/v2/${process.env.REACT_APP_ALCHEMY_MUMBAI_API_KEY as string}`)
+    },
     autoConnect: true,
     pollingInterval: 10_000,
     escapeHatches: {
@@ -285,7 +277,7 @@ const DEFAULT_PROPS: PstlWeb3ModalProps = {
       // }
     }
   }
-}
+} as const satisfies PstlWeb3ModalProps<typeof chains>
 
 const DEFAULT_PROPS_WEB3AUTH: PstlWeb3ModalProps = {
   ...DEFAULT_PROPS,

--- a/packages/web3-modal/src/hooks/internal/useCreateWagmiClient.ts
+++ b/packages/web3-modal/src/hooks/internal/useCreateWagmiClient.ts
@@ -1,6 +1,8 @@
+import { devWarn } from '@past3lle/utils'
+import defaultsDeep from 'lodash.defaultsdeep'
 import { useMemo } from 'react'
-import { Chain, Transport, http } from 'viem'
-import { Connector, WagmiProviderProps, createConfig } from 'wagmi'
+import { Chain, createClient, http } from 'viem'
+import { Connector, WagmiProviderProps, createConfig, fallback } from 'wagmi'
 import { walletConnect } from 'wagmi/connectors'
 
 import { Z_INDICES } from '../../constants'
@@ -27,22 +29,24 @@ declare module 'wagmi' {
 }
 
 export type WagmiClient = ReturnType<typeof createConfig>
-export type PstlWagmiClientOptions<chains extends readonly [Chain, ...Chain[]]> = {
-  client?: WagmiClient
-  options: Partial<CreateWagmiClientProps<chains>['options']>
-}
 
 export function useCreateWagmiClient<chains extends ReadonlyChains>(
   props: PstlWeb3ModalProps<chains>
 ): ReturnType<typeof createWagmiClient> {
   return useMemo(() => {
+    if (!!(props?.clients?.wagmi?.options && Object.keys(props?.clients.wagmi.options).length)) {
+      devWarn(
+        '[@past3lle/web3-modal] WARNING! You are passing both "clients.wagmi.options" AND "options" which is unstable and will not be possible in the next major version (3.x). Please copy all properties from "clients.wagmi.options" and move them to the root "options" configuration property.'
+      )
+    }
     return !props.clients?.wagmi?.client
       ? createWagmiClient({
           appName: props.appName,
           chains: props.chains,
           connectors: props?.connectors || [],
           walletConnect: props.modals.walletConnect,
-          options: { ...props?.clients?.wagmi?.options, ...props.options }
+          // TODO: remove this for just props.options when we deprecate clients.wagmi.options
+          options: defaultsDeep(props.options, props?.clients?.wagmi?.options)
         })
       : props.clients.wagmi.client
   }, [props.clients?.wagmi, props.appName, props.chains, props.connectors, props.modals.walletConnect, props.options])
@@ -78,14 +82,6 @@ function createWagmiClient<chains extends readonly [Chain, ...Chain[]]>({
   options,
   ...props
 }: CreateWagmiClientProps<chains>): WagmiProviderProps['config'] {
-  const transportsMap = props.chains.reduce(
-    (acc, chain) => ({
-      ...acc,
-      [chain.id]: http(chain.rpcUrls.default.http[0])
-    }),
-    {} as Record<chains[number]['id'], Transport>
-  )
-
   const connectors = [
     walletConnect({
       projectId: props.walletConnect.projectId,
@@ -107,7 +103,14 @@ function createWagmiClient<chains extends readonly [Chain, ...Chain[]]>({
   const client = createConfig({
     chains: props.chains,
     connectors,
-    transports: { ...transportsMap, ...options?.transports },
+    client({ chain }) {
+      const userTransports = options?.transports?.[chain.id as chains[number]['id']]
+      const defaultTransports = chain.rpcUrls.default.http.map((url) => http(url))
+      return createClient({
+        chain,
+        transport: fallback(userTransports ? [userTransports, ...defaultTransports] : defaultTransports)
+      })
+    },
     multiInjectedProviderDiscovery: !!options?.multiInjectedProviderDiscovery
   })
 

--- a/packages/web3-modal/src/providers/index.tsx
+++ b/packages/web3-modal/src/providers/index.tsx
@@ -4,9 +4,9 @@ import { WagmiProviderProps } from 'wagmi'
 import { PstlWeb3Modal } from '../components'
 import { TransactionsUpdater } from '../controllers/TransactionsCtrl/updater'
 import { useAutoSwitchToChain } from '../hooks/internal/useAutoSwitchToChain'
-import { PstlWagmiClientOptions, useCreateWagmiClient } from '../hooks/internal/useCreateWagmiClient'
+import { useCreateWagmiClient } from '../hooks/internal/useCreateWagmiClient'
 import { useUpdateUserConfigState } from '../hooks/state/useUpdateUserConfigState'
-import type { PstlWeb3ModalProps } from './types'
+import type { PstlWagmiClientOptions, PstlWeb3ModalProps } from './types'
 import { PstlWagmiProvider } from './wagmi'
 
 const PstlW3ProvidersBase = <chains extends WagmiProviderProps['config']['chains']>({


### PR DESCRIPTION
1. mark as `deprecated` `clients.wagmi.options`
2. default to `fallback` of chains `http` transports list
3. use chain-aware client prop in `createConfig`