### PR TITLE
fix(web3 modal): css and theme props

### DIFF
--- a/packages/web3-modal/src/components/modals/AccountModal/styled.ts
+++ b/packages/web3-modal/src/components/modals/AccountModal/styled.ts
@@ -33,6 +33,9 @@ export const AddressAndBalanceColumnContainer = styled(ModalContainer).attrs((pr
   overflowY: 'revert',
   ...props
 }))<{ backgroundColor?: string; cursor: string }>`
+  border: ${(props) => props.theme.modals?.account?.container?.main?.border?.border};
+  border-color: ${(props) => props.theme.modals?.account?.container?.main?.border?.color};
+
   > ${Column}:first-child {
     flex: 0 1 65%;
     min-width: max-content;
@@ -72,6 +75,9 @@ export const WalletAndNetworkRowContainer = styled(ModalContainer).attrs((props)
   overflowY: 'revert',
   ...props
 }))<{ backgroundColor?: string; cursor: string }>`
+  border: ${(props) => props.theme.modals?.account?.container?.main?.border?.border};
+  border-color: ${(props) => props.theme.modals?.account?.container?.main?.border?.color};
+
   background-color: ${({ theme, modal, backgroundColor = theme.modals?.[modal]?.container?.alternate?.background }) =>
     backgroundColor};
   z-index: 1;

--- a/packages/web3-modal/src/components/modals/common/PoweredByLabel.tsx
+++ b/packages/web3-modal/src/components/modals/common/PoweredByLabel.tsx
@@ -1,10 +1,21 @@
 import { Row } from '@past3lle/components'
-import { setBestTextColour } from '@past3lle/theme'
 import { MakeOptional } from '@past3lle/types'
 import React from 'react'
 import styled from 'styled-components'
 
 import { ContainerThemeTypes, ModalText } from './styled'
+
+const AttributionText = styled(ModalText).attrs((props: any) => ({
+  color: props.theme.modals?.base?.attribution?.color
+}))`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 5px;
+  > img {
+    width: 40px;
+  }
+`
 
 const PoweredByLabelContainer = styled(Row).attrs({
   justifyContent: 'center',
@@ -13,19 +24,6 @@ const PoweredByLabelContainer = styled(Row).attrs({
   padding: '3px'
 })<ContainerThemeTypes>`
   z-index: 500;
-  > ${ModalText} {
-    color: ${({ theme: { modals }, modal }) =>
-      modals?.[modal]?.background?.main
-        ? setBestTextColour(modals?.base?.background?.main as string, 7)
-        : modals?.[modal]?.font?.color};
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    gap: 5px;
-    > img {
-      width: 40px;
-    }
-  }
 
   a {
     color: inherit;
@@ -42,14 +40,14 @@ const PoweredByLabelContainer = styled(Row).attrs({
 export function PoweredByLabel({ modal = 'base', node = 'main' }: MakeOptional<ContainerThemeTypes, 'modal' | 'node'>) {
   return (
     <PoweredByLabelContainer modal={modal} node={node} title="POWERED BY PAST3LLE LABS">
-      <ModalText modal="base" node="subHeader" fontSize={10}>
+      <AttributionText modal="base" node="subHeader" fontSize={10}>
         <a href="https://pastellelabs.com?=referrer=pstl-web3-modal" target="_blank" referrerPolicy="no-referrer">
           POWERED BY{' '}
-          <ModalText modal="base" node="strong" display="inline-block">
+          <AttributionText modal="base" node="strong" display="inline-block">
             PAST3LLE LABS
-          </ModalText>
+          </AttributionText>
         </a>
-      </ModalText>
+      </AttributionText>
     </PoweredByLabelContainer>
   )
 }

--- a/packages/web3-modal/src/fixtures/config.tsx
+++ b/packages/web3-modal/src/fixtures/config.tsx
@@ -72,6 +72,9 @@ export const pstlModalTheme = createTheme({
           color: 'ghostwhite',
           background: 'rgba(255,255,255,0.1)'
         },
+        attribution: {
+          color: 'green'
+        },
         title: {
           font: {
             color: '#cbb9ee',
@@ -137,10 +140,18 @@ export const pstlModalTheme = createTheme({
         },
         container: {
           main: {
-            background: '#1113107a'
+            background: '#1113107a',
+            border: {
+              border: '2px solid',
+              color: 'rgba(120,110,40,0.65)'
+            }
           },
           alternate: {
-            background: '#1113107a'
+            background: '#1113107a',
+            border: {
+              border: '2px solid',
+              color: 'rgba(120,110,40,0.65)'
+            }
           }
         }
       },

--- a/packages/web3-modal/src/theme/baseTheme.ts
+++ b/packages/web3-modal/src/theme/baseTheme.ts
@@ -140,6 +140,9 @@ const PstlModalTheme: ThemeByModes<PstlModalThemeExtension> = {
               weight: 300
             }
           },
+          attribution: {
+            color: ''
+          },
           title: {
             font: {
               ...DEFAULT_FONT_PROPS,

--- a/packages/web3-modal/src/theme/types.ts
+++ b/packages/web3-modal/src/theme/types.ts
@@ -88,6 +88,9 @@ export interface BaseModalTheme extends SharedModalTheme {
     font?: FontStyles
     margin?: string
   }
+  attribution?: {
+    color?: string
+  }
   input?: {
     border?: BorderStyles
     background?: BackgroundStyles['main']


### PR DESCRIPTION
## Changes
Thanks for @mariavarvaroi for bringing these up

1. fix `border` and `border-color` props on `account` modal containers missing from `V1` -> `V2` upgrade
2. pass an `attribution` theme prop for setting the attribution CSS