### PR TITLE
web3-modal: update docs, replace `addConnector` with `injected`

### DIFF
--- a/examples/next-app/src/web3/config/connectors.ts
+++ b/examples/next-app/src/web3/config/connectors.ts
@@ -1,37 +1,39 @@
-import { LedgerHIDConnector } from '@past3lle/wagmi-connectors/LedgerHIDConnector'
-import { addConnector } from '@past3lle/web3-modal'
-import { InjectedConnector } from 'wagmi/connectors/injected'
-// import { LedgerConnector } from 'wagmi/connectors/ledger'
-import { MetaMaskConnector } from 'wagmi/connectors/metaMask'
+import { injected } from 'wagmi/connectors'
 
 export const CONNECTORS_CONFIG = [
-  // addConnector(LedgerConnector, {
-  //   projectId: WALLETCONNECT_CONFIG['projectId'],
-  //   walletConnectVersion: 2
-  // }),
-  addConnector(MetaMaskConnector, {
-    name: 'MetaMask',
+  injected({
     shimDisconnect: true,
-    getProvider() {
-      if (typeof global?.window === undefined) return undefined
-      return global.window?.ethereum?.providerMap?.get('MetaMask') || global.window?.ethereum
+    target: {
+      name: 'MetaMask',
+      id: 'metamask',
+      provider(window) {
+        if (typeof window === 'undefined') return undefined
+        return (
+          (window as any)?.ethereum?.providerMap?.get('MetaMask') || (window.ethereum?.isMetaMask && window?.ethereum)
+        )
+      }
     }
   }),
-  addConnector(InjectedConnector, {
-    name: 'CoinbaseWallet',
+  injected({
     shimDisconnect: true,
-    getProvider() {
-      if (typeof global.window === undefined) return undefined
-      return global.window?.coinbaseWalletExtension
+    target: {
+      name: 'CoinbaseWallet',
+      id: 'coinbaseWallet',
+      provider(window) {
+        if (typeof window === 'undefined') return undefined
+        return window?.coinbaseWalletExtension
+      }
     }
   }),
-  addConnector(InjectedConnector, {
-    name: 'Taho',
+  injected({
     shimDisconnect: true,
-    getProvider() {
-      if (typeof global.window === undefined) return undefined
-      return global.window?.tally
+    target: {
+      name: 'Taho',
+      id: 'taho',
+      provider(window) {
+        if (typeof window === 'undefined') return undefined
+        return (window as any)?.tally
+      }
     }
-  }),
-  addConnector(LedgerHIDConnector, undefined)
+  })
 ]

--- a/packages/wagmi-connectors/README.md
+++ b/packages/wagmi-connectors/README.md
@@ -6,17 +6,16 @@
 
 # Example
 ```ts
-import { IFrameEthereumConnector, LedgerHIDConnector } from '@past3lle/wagmi-connectors'
-import { addConnector } from '@past3lle/web3-modal'
+import { iframeEthereum, ledgerLive, ledgerHid } from '@past3lle/wagmi-connectors';
 
 export const wagmiConnectors = {
-  ledgerLiveModal: addConnector(LedgerConnector, {
-    enableDebugLogs: false,
-    walletConnectVersion: 2,
-    projectId: WALLETCONNECT_ID,
-    requiredChains: [1]
-  }),
-  ledgerHID: addConnector(LedgerHIDConnector, {}),
-  ledgerIFrame: addConnector(IFrameEthereumConnector, {})
+  ledgerLiveModal: ledgerLive({}),
+  ledgerHID: ledgerHid({
+                name: 'Ledger HID',
+                shimDisconnect: true,
+            }),
+  ledgerIFrame: iframeEthereum({
+                  name: 'Ledger IFrame',
+            }),
 }
 ```

--- a/packages/web3-modal/README.md
+++ b/packages/web3-modal/README.md
@@ -45,8 +45,10 @@ export default modalTheme
 
 ### 2: Create a config.ts file
 ```tsx
-import { PstlWeb3ModalProps, addConnector } from '@past3lle/web3-modal'
+import {ledgerLive, ledgerHid } from '@past3lle/wagmi-connectors';
+import { PstlWeb3ModalProps } from '@past3lle/web3-modal'
 import { mainnet } from '@wagmi/chains'
+import { injected } from 'wagmi/connectors'
 import modalTheme, { PALETTE } from 'theme'
 
 import { LedgerConnector } from 'wagmi/connectors/ledger'
@@ -80,17 +82,19 @@ const config = {
   chains,
   connectors: [
       // Adds LedgerHID connector
-      addConnector(LedgerHIDConnector, {}),
+      ledgerHID: ledgerHid({
+                name: 'Ledger HID',
+                shimDisconnect: true,
+            }),
       // Adds LedgerLive modal connector
-      addConnector(LedgerConnector, { 
-        projectId: WALLETCONNECT_PROJECT_ID, 
-        walletConnectVersion: 2 
-      }),
+      ledgerLive({}),
       // Adds MetaMask injected connector
-      addConnector(InjectedConnector, {
+      injected({
+      shimDisconnect: true,
+      target: {
         name: 'MetaMask',
-        shimDisconnect: true,
-        getProvider() {
+        id: 'metamask',
+        provider(window) {
           try {
             // You may need to (window as any)?.ethereum? ...
             // Or create a declarations.d.ts file in your /src/ root
@@ -101,7 +105,8 @@ const config = {
             return undefined
           }
         }
-      }),
+      }
+    }),
   ],
   options: {
     // How often to poll for new data


### PR DESCRIPTION
Update docs:

- [x] remove use of deprecated `addConnector`
- [x] use `injected` , `ledgerLive`, `ledgerHid`