### PR TITLE
chore(web3-modal): add clarification comments to default exported modals

### DIFF
--- a/packages/web3-modal/src/components/modals/AccountModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/AccountModal/index.tsx
@@ -245,4 +245,5 @@ function useModalTheme(): PstlModalTheme['modals'] {
   return theme.modals
 }
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(AccountModalContent)

--- a/packages/web3-modal/src/components/modals/ConfigTypeModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/ConfigTypeModal/index.tsx
@@ -105,4 +105,5 @@ function NetworkModalContent() {
   )
 }
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(NetworkModalContent)

--- a/packages/web3-modal/src/components/modals/ConnectionModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/ConnectionModal/index.tsx
@@ -155,4 +155,5 @@ function ConnectionModalContent({
   )
 }
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(ConnectionModalContent)

--- a/packages/web3-modal/src/components/modals/ErrorModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/ErrorModal/index.tsx
@@ -5,6 +5,7 @@ import { ModalText, ModalTitleText } from '../common/styled'
 
 const IS_SERVER = typeof globalThis?.window === 'undefined'
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default function ErrorModal() {
   return (
     <BaseModal

--- a/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
@@ -363,4 +363,5 @@ const SELECTOR_OPTIONS = [
   }
 ]
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(HidDeviceOptionsContent)

--- a/packages/web3-modal/src/components/modals/NetworkModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/NetworkModal/index.tsx
@@ -72,4 +72,5 @@ function NetworkModalContent() {
   )
 }
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(NetworkModalContent)

--- a/packages/web3-modal/src/components/modals/TransactionsModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/TransactionsModal/index.tsx
@@ -359,4 +359,5 @@ const _sortBy =
         : (a[sortByKey] as number) - (b[sortByKey] as number)
       : 0
 
+// Exported as default for lazy import inside /components/modals/index.tsx
 export default memo(TransactionModalContent)

--- a/packages/web3-modal/src/theme/baseTheme.ts
+++ b/packages/web3-modal/src/theme/baseTheme.ts
@@ -53,7 +53,7 @@ const MAIN_COLOURS = {
   url: 'unset'
 }
 
-const PstlModalTheme: ThemeByModes<PstlModalThemeExtension> = {
+export const PstlModalTheme: ThemeByModes<PstlModalThemeExtension> = {
   modes: {
     LIGHT: {},
     DARK: {},
@@ -255,5 +255,3 @@ const PstlModalTheme: ThemeByModes<PstlModalThemeExtension> = {
     }
   }
 }
-
-export default PstlModalTheme

--- a/packages/web3-modal/src/theme/creator.ts
+++ b/packages/web3-modal/src/theme/creator.ts
@@ -1,7 +1,7 @@
 import { Subset, createTemplateThemeFactory } from '@past3lle/theme'
 import { MakeOptional } from '@past3lle/types'
 
-import PstlModalTheme from './baseTheme'
+import { PstlModalTheme } from './baseTheme'
 import { PstlModalThemeExtension } from './types'
 
 const templates = {


### PR DESCRIPTION
web3-modal: add clarification comments to default exported modals
web3-modal: change default export of `pstlModalTheme` to named export