### PR TITLE
fix(web3-modal): update transactions styling logic & transactions theme type

### DIFF
--- a/packages/web3-modal/src/components/modals/TransactionsModal/styled.tsx
+++ b/packages/web3-modal/src/components/modals/TransactionsModal/styled.tsx
@@ -49,7 +49,7 @@ export const TransactionRow = styled(RowBetween)<{ fontSize?: string; borderBott
   }
 `
 
-export const TransactionTitle = styled(ModalText).attrs({ modal: 'base', node: 'subHeader' })``
+export const TransactionTitle = styled(ModalText).attrs({ modal: 'transactions', node: 'subHeader' })``
 export const TransactionWrapper = styled(Column)<{ background?: string }>`
   color: ghostwhite;
   background: ${(props) => props.background};
@@ -71,7 +71,7 @@ export const TransactionsModalWrapper = styled(ModalContainer).attrs({ modal: 't
   padding: 0.7rem;
 
   a {
-    color: ${(props) => props.theme.modals?.base?.text?.anchor?.color};
+    color: ${(props) => props.theme.modals?.transactions?.text?.anchor?.color};
   }
 `
 

--- a/packages/web3-modal/src/fixtures/config.tsx
+++ b/packages/web3-modal/src/fixtures/config.tsx
@@ -155,7 +155,24 @@ export const pstlModalTheme = createTheme({
           }
         }
       },
-      transactions: {}
+      transactions: {
+        text: {
+          subHeader: { color: 'orange' },
+          main: { color: 'red' },
+          strong: { color: 'red' },
+          small: { color: 'red' },
+          anchor: { color: 'yellow' }
+        },
+        card: {
+          background: { success: 'indianred', error: 'black' },
+          statusPill: {
+            statusText: {
+              success: 'orange',
+              pending: 'navajowhite'
+            }
+          }
+        }
+      }
     }
   },
   get DARK() {

--- a/packages/web3-modal/src/theme/types.ts
+++ b/packages/web3-modal/src/theme/types.ts
@@ -135,7 +135,6 @@ export interface TransactionsModalTheme extends SharedModalTheme {
      * Background of the card.
      */
     background: Pick<BackgroundStyles, 'success' | 'error'>
-    text?: SharedModalTheme['text']
     statusPill?: {
       /**
        * Colour of the text inside the pill.


### PR DESCRIPTION
Merges into #77 

Fixes some of the transaction styling issues and updates `web3-modal/src/fixtures/config.tsx` theme to reflect available changes in action

### Example config
<img width="521" alt="image" src="https://github.com/PAST3LLE/monorepo/assets/21335563/ae0870c9-e00c-4835-8a99-f56fda1fa5a3">

Gives us
<img width="563" alt="image" src="https://github.com/PAST3LLE/monorepo/assets/21335563/3e0aef4d-5a89-4d74-8d51-f0650486523d">

Which is horrible, but that's besides the point ;)

## Changes
1. update theme/types
2. update styled component modal type from `base` to `transactions`
3. chore: update config.tsx inside `fixtures`