### PR TITLE
web3-modal: enabled option to add custom safe url

### DIFF
--- a/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
+++ b/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
@@ -19,7 +19,7 @@ async function _getChainFromUrl(
   chains: PstlWeb3ModalProps['chains'],
   config?: PstlWeb3ModalProps
 ): Promise<Chain | undefined> {
-  const status = getAppType(config?.options?.escapeHatches?.appType, config?.options?.escapeHatches?.customSafeUrl)
+  const status = getAppType(config?.options?.escapeHatches?.appType, config?.options?.customSafeUrl)
 
   switch (status) {
     case 'TEST_FRAMEWORK_IFRAME':

--- a/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
+++ b/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
@@ -19,7 +19,7 @@ async function _getChainFromUrl(
   chains: PstlWeb3ModalProps['chains'],
   config?: PstlWeb3ModalProps
 ): Promise<Chain | undefined> {
-  const status = getAppType(config?.options?.escapeHatches?.appType)
+  const status = getAppType(config?.options?.escapeHatches?.appType, config?.options?.escapeHatches?.customSafeUrl)
 
   switch (status) {
     case 'TEST_FRAMEWORK_IFRAME':

--- a/packages/web3-modal/src/providers/types.ts
+++ b/packages/web3-modal/src/providers/types.ts
@@ -1,11 +1,14 @@
-import { Chain } from 'viem'
-import { Config, CreateConfigParameters, CreateConnectorFn, WagmiProviderProps } from 'wagmi'
-import { walletConnect } from 'wagmi/connectors'
+import { Chain } from 'viem';
+import { Config, CreateConfigParameters, CreateConnectorFn, WagmiProviderProps } from 'wagmi';
+import { walletConnect } from 'wagmi/connectors';
 
-import { PstlWeb3ConnectionModalProps } from '../components/modals/ConnectionModal'
-import { UserOptionsTransactionsCallbacks } from '../controllers/types'
-import { ConnectorEnhanced, ConnectorOverrides } from '../types'
-import { AppType } from '../utils/connectors'
+
+
+import { PstlWeb3ConnectionModalProps } from '../components/modals/ConnectionModal';
+import { UserOptionsTransactionsCallbacks } from '../controllers/types';
+import { ConnectorEnhanced, ConnectorOverrides } from '../types';
+import { AppType } from '../utils/connectors';
+
 
 export interface ConfigCtrlState {
   projectId: string
@@ -133,11 +136,6 @@ export type PstlWeb3ModalOptions<chains extends ReadonlyChains = ReadonlyChains>
      * @description appType is detected and set automtically elsewhere. Escape hatch
      */
     appType?: AppType
-    /**
-     * @name customSafeUrl
-     * @description Custom Safe URL. Useful for testing.
-     */
-    customSafeUrl?: string
   }
   /**
    * @name closeModalOnKeys
@@ -148,6 +146,11 @@ export type PstlWeb3ModalOptions<chains extends ReadonlyChains = ReadonlyChains>
    * @name expiremental
    * @description Map of experimental feature flags
    */
+  /**
+   * @name customSafeUrl
+   * @description Custom Safe URL. Useful for testing.
+   */
+  customSafeUrl?: string
   experimental?: {
     /**
      * @name hidDeviceOptions

--- a/packages/web3-modal/src/providers/types.ts
+++ b/packages/web3-modal/src/providers/types.ts
@@ -133,6 +133,11 @@ export type PstlWeb3ModalOptions<chains extends ReadonlyChains = ReadonlyChains>
      * @description appType is detected and set automtically elsewhere. Escape hatch
      */
     appType?: AppType
+    /**
+     * @name customSafeUrl
+     * @description Custom Safe URL. Useful for testing.
+     */
+    customSafeUrl?: string
   }
   /**
    * @name closeModalOnKeys

--- a/packages/web3-modal/src/utils/connectors.ts
+++ b/packages/web3-modal/src/utils/connectors.ts
@@ -19,8 +19,9 @@ export function getAppType(forcedAppType?: AppType, customSafeUrl?: string) {
     return 'TEST_FRAMEWORK_IFRAME'
   } else if (isIframe() || isLedgerDappBrowserProvider()) {
     const isLedgerLive = isLedgerDappBrowserProvider()
-    const isCustomSafe = customSafeUrl ? window?.location.ancestorOrigins.item(0)?.includes(customSafeUrl) : false
-    const isSafe = window?.location.ancestorOrigins.item(0)?.includes('app.safe.global') || isCustomSafe
+    const isSafe = ['app.safe.global', customSafeUrl].some((url) =>
+      url ? window?.location.ancestorOrigins.item(0)?.includes(url) : false
+    )
     return isSafe ? 'SAFE_APP' : isLedgerLive ? 'LEDGER_LIVE' : 'IFRAME'
   } else {
     return 'DAPP'
@@ -74,10 +75,7 @@ export function getConfigFromAppType(
   }
 ): { chains: typeof configProps.chains; connectors: (CreateConnectorFn | Connector)[] } {
   const chains = hardFilterChains({ callbacks: configProps.callbacks, chains: configProps.chains })
-  const status = getAppType(
-    configProps.options?.escapeHatches?.appType,
-    configProps.options?.escapeHatches?.customSafeUrl
-  )
+  const status = getAppType(configProps.options?.escapeHatches?.appType, configProps.options?.customSafeUrl)
   switch (status) {
     case 'SAFE_APP': {
       devDebug('[@past3lle/web3-modal] App type detected: SAFE APP')


### PR DESCRIPTION
## Context
At the moment safe app is not available of holesky chain. This makes it difficult to test dapps that use holesky. There is an alternative safe app on holesky deployed at https://holesky-safe.protofire.io/. 

## Issue
The modal does not recognise this as a valid safe app because it checks for the parent url of the iframe and matches it to app.safe.global. 

## Solution
Add an optional key in config to allow `customSafeUrl`. This url will be used in addition to the official safe url to determine if the dapp is open inside a safe. 
The key is added inside `escapeHatches` alongside `appType` in config. Please let me know if there is a better place to move it. 