### PR TITLE
web3-modal: enabled option to add custom safe url

### DIFF
--- a/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
+++ b/packages/web3-modal/src/hooks/internal/useAutoSwitchToChain.ts
@@ -19,7 +19,7 @@ async function _getChainFromUrl(
   chains: PstlWeb3ModalProps['chains'],
   config?: PstlWeb3ModalProps
 ): Promise<Chain | undefined> {
-  const status = getAppType(config?.options?.escapeHatches?.appType)
+  const status = getAppType(config?.options?.escapeHatches?.appType, config?.options?.customSafeUrl)
 
   switch (status) {
     case 'TEST_FRAMEWORK_IFRAME':

--- a/packages/web3-modal/src/providers/types.ts
+++ b/packages/web3-modal/src/providers/types.ts
@@ -143,6 +143,11 @@ export type PstlWeb3ModalOptions<chains extends ReadonlyChains = ReadonlyChains>
    * @name expiremental
    * @description Map of experimental feature flags
    */
+  /**
+   * @name customSafeUrl
+   * @description Custom Safe URL. Useful for testing.
+   */
+  customSafeUrl?: string
   experimental?: {
     /**
      * @name hidDeviceOptions

--- a/packages/web3-modal/src/utils/connectors.ts
+++ b/packages/web3-modal/src/utils/connectors.ts
@@ -12,14 +12,16 @@ import { isLedgerDappBrowserProvider } from './iframe'
 import { connectorOverridePropSelector } from './misc'
 
 export type AppType = 'IFRAME' | 'SAFE_APP' | 'LEDGER_LIVE' | 'DAPP' | 'TEST_FRAMEWORK_IFRAME'
-export function getAppType(forcedAppType?: AppType) {
+export function getAppType(forcedAppType?: AppType, customSafeUrl?: string) {
   if (!!forcedAppType) return forcedAppType
   else if (process.env.IS_COSMOS) {
     devDebug('[@past3lle/web3-modal::getAppType] TEST_FRAMEWORK_IFRAME detected, returning connectors unaffected')
     return 'TEST_FRAMEWORK_IFRAME'
   } else if (isIframe() || isLedgerDappBrowserProvider()) {
     const isLedgerLive = isLedgerDappBrowserProvider()
-    const isSafe = window?.location.ancestorOrigins.item(0)?.includes('app.safe.global')
+    const isSafe = ['app.safe.global', customSafeUrl].some((url) =>
+      url ? window?.location.ancestorOrigins.item(0)?.includes(url) : false
+    )
     return isSafe ? 'SAFE_APP' : isLedgerLive ? 'LEDGER_LIVE' : 'IFRAME'
   } else {
     return 'DAPP'
@@ -73,7 +75,7 @@ export function getConfigFromAppType(
   }
 ): { chains: typeof configProps.chains; connectors: (CreateConnectorFn | Connector)[] } {
   const chains = hardFilterChains({ callbacks: configProps.callbacks, chains: configProps.chains })
-  const status = getAppType(configProps.options?.escapeHatches?.appType)
+  const status = getAppType(configProps.options?.escapeHatches?.appType, configProps.options?.customSafeUrl)
   switch (status) {
     case 'SAFE_APP': {
       devDebug('[@past3lle/web3-modal] App type detected: SAFE APP')


### PR DESCRIPTION
## Context
At the moment safe app is not available of holesky chain. This makes it difficult to test dapps that use holesky. There is an alternative safe app on holesky deployed at https://holesky-safe.protofire.io/. 

## Issue
The modal does not recognise this as a valid safe app because it checks for the parent url of the iframe and matches it to app.safe.global. 

## Solution
Add an optional key in config to allow `customSafeUrl`. This url will be used in addition to the official safe url to determine if the dapp is open inside a safe. 
