### PR TITLE
Fix HID modal issues

### DIFF
--- a/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/hooks.ts
+++ b/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/hooks.ts
@@ -108,6 +108,7 @@ export function useHidModalStore({ chainId, connector, path, paginationAmount }:
           _isValidPathOrThrow(path)
           _isConnectedOrThrow(hid)
           setLoading(true)
+          const provider = await hid?.getProvider?.()
 
           const accountsAndBalances: { address: Address; balance: string | undefined }[] = []
           for (let i = paginationIdx - paginationAmount; i < paginationIdx; i++) {
@@ -116,7 +117,7 @@ export function useHidModalStore({ chainId, connector, path, paginationAmount }:
             const [acct] = (await hid?.getAccounts(replacedPath)) || []
             // We throw if no path found at derived address
             if (!acct) throw new Error('No valid account found at path: ' + replacedPath)
-            const bal = await hid?.provider?.getBalance(acct)
+            const bal = await provider?.getBalance(acct)
             accountsAndBalances.push({ address: acct, balance: bal ? formatEther(BigInt(bal.toString())) : '0' })
             continue
           }

--- a/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/hooks.ts
+++ b/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/hooks.ts
@@ -17,8 +17,6 @@ type Params = {
   paginationAmount: number
 }
 
-const DEFAULT_ACCOUNT_INDEX = parseFloat(localStorage.getItem(KEYS.HID_ACCOUNT_INDEX) || '0')
-
 export function useHidModalStore({ chainId, connector, path, paginationAmount }: Params) {
   const { close } = usePstlWeb3Modal()
   const {
@@ -26,7 +24,9 @@ export function useHidModalStore({ chainId, connector, path, paginationAmount }:
       error: { set: setError, reset: resetError }
     }
   } = usePstlWeb3ModalStore()
-  const [selectedAccountIdx, setSelectedAccountIdx] = useState<number>(() => DEFAULT_ACCOUNT_INDEX)
+  const [selectedAccountIdx, setSelectedAccountIdx] = useState<number>(() =>
+    parseFloat(localStorage.getItem(KEYS.HID_ACCOUNT_INDEX) || '0')
+  )
   const [accountsAndBalances, setAccountsAndBalances] = useState<{ address: string; balance: string | undefined }[]>([])
 
   const [loading, setLoading] = useState(false)

--- a/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
@@ -245,7 +245,7 @@ function HidDeviceOptionsContent({ errorOptions }: PstlHidDeviceModalProps) {
               </ModalSubHeaderText>
               <HidModalTextInput
                 value={isCustomPath ? path ?? '' : ''}
-                placeholder={"m / 44' 60' / *' / 0 / 0"}
+                placeholder={"m/44'/60'/*'/0/0"}
                 minWidth={isCustomPath ? '300px' : 'min-content'}
                 fontWeight={isCustomPath ? 300 : 100}
                 onChange={(e) => {

--- a/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
+++ b/packages/web3-modal/src/components/modals/HidDeviceOptionsModal/index.tsx
@@ -45,7 +45,6 @@ type PstlHidDeviceModalProps = Pick<BaseModalProps, 'errorOptions'>
 const PAGINATION_AMT = 5
 const CHAIN_IMAGE_STYLES = { width: 20, height: 20, marginLeft: 7, borderRadius: '30%' }
 
-const DEFAULT_PATH = localStorage.getItem(KEYS.HID_DERIVATION_PATH) ?? SUPPORTED_BIP_DERIVATION_PATHS[0]
 const DISABLED_SELECTOR_COLOR = 'darkgrey'
 
 function HidDeviceOptionsContent({ errorOptions }: PstlHidDeviceModalProps) {
@@ -74,7 +73,9 @@ function HidDeviceOptionsContent({ errorOptions }: PstlHidDeviceModalProps) {
   )
 
   const { connector: hidConnector } = useUserConnectionInfo()
-  const { dbPath, path, isCustomPath, ...pathCallbacks } = useHidModalPath(DEFAULT_PATH)
+  const { dbPath, path, isCustomPath, ...pathCallbacks } = useHidModalPath(
+    localStorage.getItem(KEYS.HID_DERIVATION_PATH) ?? SUPPORTED_BIP_DERIVATION_PATHS[0]
+  )
 
   const { accountsAndBalances, loading, loadedSavedConfig, paginationIdx, selectedAccountIdx, ...storeCallbacks } =
     useHidModalStore({


### PR DESCRIPTION
This PR addresses 3 issues related to the HID Options Modal:
1. The custom HD input placeholder has a typo - missing "/", also remove spaces to match select - "m/44'/60'/*'/0/0"
2. `hid?.provider` returns `undefined` which results in 0 ETH balances for all derived addresses in the table, so use `getProvider` instead
3. `DEFAULT_ACCOUNT_INDEX` & `DEFAULT_PATH` get evaluated only once when the app is loaded for the first time. So if the user opens the HID modal, makes a change there, and then reopens it, the path & address reset to the initial, instead of keeping the last one. Evaluating the account index & path on each mount solves the issue