### PR TITLE
Handle Ledger HID 0x6e00 error

### DIFF
--- a/packages/wagmi-connectors/src/ledgerHid/errorCodes.ts
+++ b/packages/wagmi-connectors/src/ledgerHid/errorCodes.ts
@@ -1,9 +1,10 @@
-export type ErrorCodes = 27906
+export type ErrorCodes = 27906 | 28160
 
 type ErrorMessages = {
   [code in ErrorCodes]: string
 }
 
 export const ERROR_MESSAGES: ErrorMessages = {
-  [27906]: 'Ledger locked! Please unlock and make sure your Ethereum app is open.'
+  [27906]: 'Ledger locked! Please unlock and make sure your Ethereum app is open.',
+  [28160]: 'Ledger device: CLA_NOT_SUPPORTED (0x6e00). Make sure the Ethereum app is open on the device.'
 }

--- a/packages/wagmi-connectors/src/ledgerHid/index.ts
+++ b/packages/wagmi-connectors/src/ledgerHid/index.ts
@@ -180,6 +180,7 @@ export function ledgerHid(parameters?: LedgerHidParameters) {
         const statusCode: ErrorCodes | undefined = (error as any)?.statusCode
         switch (statusCode) {
           case 27906:
+          case 28160:
             throw new Error(ERROR_MESSAGES[statusCode])
           default:
             throw error


### PR DESCRIPTION
When a user opens the Bitcoin app on Ledger, and then try to connect to the app via the Ledger HID connector they get the error:

*"Ledger device: CLA_NOT_SUPPORTED (0x6e00)"*. 

This PR adds a better message to handle this case

![image](https://github.com/PAST3LLE/monorepo/assets/357029/c3d84414-e91e-4cf1-a9d7-c5bc5bfc793a)
